### PR TITLE
Redone landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,47 @@
-# :fontawesome-solid-microchip: About
+#Documentation Overview
 
-![HPC unit signature](assets/HPC-unit-signature.png){ width="400" align="right" }
+Welcome to the High-Performance Computing Core Facility (HPCCF) Documentation Site. These pages are intended to be a how-to for commonly asked questions about resources supported by the UC Davis High-Performance Computing Core Facility.
 
-## Using This Documentation
+HPCCF is a [core faciilty](https://research.ucdavis.edu/research-support/research-core-facilities/) reporting through the Office of Research and supported by individual university colleges, the Office of the Provost, and the Vice Chancellor for Research.  
 
-Before contacting HPCCF support, first try searching this documentation.
-This site provides information on accessing and interacting with the cluster,
-an overview of available software ecosystems, and tutorials for commonly used software and access patterns.
-It is split into a **Users** section for end-users and an **Admin** section with information relevant to system
-administrators.
-This documentation is being actively expanded as Franklin's software and userbase grows.
+Before contacting HPCCF support, first try searching this documentation. This site provides information on accessing and interacting with HPCCF supported clusters, an overview of available software ecosystems, and tutorials for commonly used software and access patterns. It is split into a Users section for end-users and an Admin section with information relevant to system administrators and advanced users.
 
-This site is written in [markdown](https://daringfireball.net/projects/markdown/) using [MkDocs](https://www.mkdocs.org) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme.
-If you would like to contribute, you may [fork our repo :material-source-fork:](https://github.com/ucdavis/hpccf-docs/fork) and submit a pull request :material-source-pull:.
+Questions about the documentation or resources supported by the HPCCF can be directed to hpc-help@ucdavis.edu.
+
+###Our Clusters:
+
+##### _Condo Clusters_
+An HPC condo-style cluster is a shared computing infrastructure where different users or groups contribute resources (such as compute nodes, storage, or networking) to a common pool, similar to how individual condo owners share common amenities.
+
+**Farm**: Sponsored by the College of Agriculture and Environmental Sciences. Farm resources can be purchased by principal investigators regardless of affiliation.    
+
+**HPC2**: Sponsored by the College of Engineering and Computer Science and is open to principal investigators associated with COE.
+
+**Peloton**: Peloton is open to principal investigators associated with the College of Letters and Science. Peloton has a shared tier open to users associated with CLAS.
+
+##### _Fair-Share Clusters_
+
+A fair-share HPC algorithm is a resource allocation strategy used to ensure equitable access to computing resources among multiple users or groups. The goal is to balance the workload and prevent any single user or group from monopolizing the resources.
+
+
+**LSSC0 (Barbera)**: an HPC shared resource which is coordinated and ran by HPCCF. LSSC0 is ran with a fair-share algorithm. 
+###Getting Started
+
+Please read the [Supported Services](https://hpc.ucdavis.edu/supported-services) page.
+
+As a new principal investigator who is interested in purchasing resources, please email hpc-help@ucdavis.edu with your affiliation to inquire about onboarding. Resources external to UC Davis can also purchase resources by inquiring at the hpc-help email address.
+
+For getting started with HPC access under an existing PI, please see [requesting an account](https://docs.hpc.ucdavis.edu/general/account-requests/).
+
+### How to ask for help:
+
+Emails sent to the HPCCF are documented in Service Now. Please include your name, relevant cluster name, account name if possible, and a brief description of your request or question. Please be patient, as HPCCF staff will respond to your inquiry as soon as possible. HPCCF staff are available on scheduled university work days and are available from 8:00 am to 5:00 pm. 
+
+### Contributing to the documentation:
+This site is written in markdown using [MkDocs](https://daringfireball.net/projects/markdown/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. If you would like to contribute, you may [fork our repo :material-source-fork:](https://github.com/ucdavis/hpccf-docs/fork) and submit a pull request.
+
+###Additional Information:
+
+- [HPCCF home page](https://hpc.ucdavis.edu)
+- [Research Computing at UC Davis](https://researchcomputing.ucdavis.edu)
+- [UC Davis DataLab](https://datalab.ucdavis.edu)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Questions about the documentation or resources supported by the HPCCF can be dir
 
 ### Our Clusters
 
-##### _Condo Clusters_
+####_Condo Clusters_
 An HPC condo-style cluster is a shared computing infrastructure where different users or groups contribute resources (such as compute nodes, storage, or networking) to a common pool, similar to how individual condo owners share common amenities.
 
 **Farm**: Sponsored by the College of Agriculture and Environmental Sciences. Farm resources can be purchased by principal investigators regardless of affiliation.    
@@ -19,7 +19,7 @@ An HPC condo-style cluster is a shared computing infrastructure where different 
 
 **Peloton**: Peloton is open to principal investigators associated with the College of Letters and Science. Peloton has a shared tier open to users associated with CLAS.
 
-##### _Fair-Share Clusters_
+#### _Fair-Share Clusters_
 
 A fair-share HPC algorithm is a resource allocation strategy used to ensure equitable access to computing resources among multiple users or groups. The goal is to balance the workload and prevent any single user or group from monopolizing the resources.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-#Documentation Overview
+# Documentation Overview
 
 Welcome to the High-Performance Computing Core Facility (HPCCF) Documentation Site. These pages are intended to be a how-to for commonly asked questions about resources supported by the UC Davis High-Performance Computing Core Facility.
 
@@ -8,7 +8,7 @@ Before contacting HPCCF support, first try searching this documentation. This si
 
 Questions about the documentation or resources supported by the HPCCF can be directed to hpc-help@ucdavis.edu.
 
-###Our Clusters:
+### Our Clusters
 
 ##### _Condo Clusters_
 An HPC condo-style cluster is a shared computing infrastructure where different users or groups contribute resources (such as compute nodes, storage, or networking) to a common pool, similar to how individual condo owners share common amenities.
@@ -24,8 +24,8 @@ An HPC condo-style cluster is a shared computing infrastructure where different 
 A fair-share HPC algorithm is a resource allocation strategy used to ensure equitable access to computing resources among multiple users or groups. The goal is to balance the workload and prevent any single user or group from monopolizing the resources.
 
 
-**LSSC0 (Barbera)**: an HPC shared resource which is coordinated and ran by HPCCF. LSSC0 is ran with a fair-share algorithm. 
-###Getting Started
+**LSSC0 (Barbera)** an HPC shared resource which is coordinated and ran by HPCCF. LSSC0 is ran with a fair-share algorithm. 
+### Getting Started
 
 Please read the [Supported Services](https://hpc.ucdavis.edu/supported-services) page.
 
@@ -33,14 +33,14 @@ As a new principal investigator who is interested in purchasing resources, pleas
 
 For getting started with HPC access under an existing PI, please see [requesting an account](https://docs.hpc.ucdavis.edu/general/account-requests/).
 
-### How to ask for help:
+### How to ask for help
 
-Emails sent to the HPCCF are documented in Service Now. Please include your name, relevant cluster name, account name if possible, and a brief description of your request or question. Please be patient, as HPCCF staff will respond to your inquiry as soon as possible. HPCCF staff are available on scheduled university work days and are available from 8:00 am to 5:00 pm. 
+Emails sent to the HPCCF are documented in Service Now via hpc-help@ucdavis.edu. Please include your name, relevant cluster name, account name if possible, and a brief description of your request or question. Please be patient, as HPCCF staff will respond to your inquiry as soon as possible. HPCCF staff are available to respond to requests on scheduled university work days and are available from 8:00 am to 5:00 pm. 
 
-### Contributing to the documentation:
+### Contributing to the documentation
 This site is written in markdown using [MkDocs](https://daringfireball.net/projects/markdown/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. If you would like to contribute, you may [fork our repo :material-source-fork:](https://github.com/ucdavis/hpccf-docs/fork) and submit a pull request.
 
-###Additional Information:
+### Additional Information
 
 - [HPCCF home page](https://hpc.ucdavis.edu)
 - [Research Computing at UC Davis](https://researchcomputing.ucdavis.edu)


### PR DESCRIPTION
Incorporated existing about page into a new landing page. Added basic information about documentation and the main clusters we support that are accepting new resources.