### PR TITLE
Added migration from LSSC0 document to new Hive section

### DIFF
--- a/docs/hive/migration.md
+++ b/docs/hive/migration.md
@@ -32,7 +32,7 @@ If you're copying files from /home/cheeto on LSSC0 to /home/cheeto on Hive, run 
 
 `rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/`
 
-Note that this will copy your home directory as-is. Consider putting your LSSC0 files into a oldhome/ directory on Hive to ensure that you're not copying over incompatible dot files.
+Note that this will copy your home directory as-is. Consider putting your LSSC0 files into an `oldhome/` directory on Hive to ensure that you're not copying over incompatible dot files.
 
 `rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/oldhome/`
 

--- a/docs/hive/migration.md
+++ b/docs/hive/migration.md
@@ -32,7 +32,7 @@ If you're copying files from /home/cheeto on LSSC0 to /home/cheeto on Hive, run 
 
 `rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/`
 
-Note that this will copy your home directory as-is. Consider putting your LSSC0 files into a oldhome/ directory on Hive to ensure that you're not copying over stale dot files.
+Note that this will copy your home directory as-is. Consider putting your LSSC0 files into a oldhome/ directory on Hive to ensure that you're not copying over incompatible dot files.
 
 `rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/oldhome/`
 
@@ -41,11 +41,10 @@ Note that this will copy your home directory as-is. Consider putting your LSSC0 
 	•	--delete: Deletes files on the destination that are not present on the source.
 	•	-e ssh: Explicitly specifies SSH as the transfer protocol (default when connecting to remote servers).
 
-Please note that you will be asked for your user password when transferring data to Hive. Your username and passphrase is your campus computing account and campus Kerberos passphrase. Alternatively, you can use SSH to transfer data by copying your private key that is associated with your Hive login to LSSC0 and including that with your rsync command as follows:
+Please note that you will be asked for your user password when transferring data to Hive. Your username and passphrase is your campus computing account and campus Kerberos passphrase. Alternatively, you can forward your SSH agent when using SSH to connect to LSSC0/Barbera:
 
-`rsync -avz -e "ssh -i /path/to/private_key" /source user@remote-server:/destination/`
-
-For example:
-
-`rsync -avz -e "ssh -i $HOME/.ssh/private_key" /home/cheeto/ cheeto@hive.hpc.ucdavis.edu:/home/cheeto/`
-
+```
+ssh-add
+ssh -A user@barbera.genomecenter.ucdavis.edu
+user@barbera:~$ rsync -avz /home/cheeto/ cheeto@hive.hpc.ucdavis.edu:/home/cheeto/oldhome/
+```

--- a/docs/hive/migration.md
+++ b/docs/hive/migration.md
@@ -1,0 +1,51 @@
+---
+title: Migrating from LSSC0
+---
+## Data migration:
+#### Home directories:
+
+Home directories on Hive are mounted on /home/<username>. For example, if your username is Cheeto, your home directory would be `/home/cheeto`. Home directories on Hive are expanded to 20G per person.
+
+#### Group directories:
+Group directories on Hive are mounted on /quobyte. Please ensure that your group or lab
+has purchased resources before you move data. Group directories are named after the PI or lab owner. 
+
+### Moving data to Hive using rsync:
+
+Please ensure you have an account on Hive by creating one at [HiPPO](https://hippo.ucdavis.edu).
+
+To use rsync to copy files from one server to another while preserving permissions, ownership, and file times, you can use the following command:
+
+`rsync -avz source/ user@destination:/path/to/target/`
+
+##### Explanation of options:
+	•	-a (archive mode): Preserves symbolic links, permissions, ownership, file timestamps, and recursively copies directories.
+	•	-v (verbose): Displays the progress and details of the transfer.
+	•	-z (compress): Compresses file data during transfer to save bandwidth.
+	•	source/: The directory or file you want to copy. The trailing slash / ensures only the contents of the directory are copied, not the directory itself.
+	•	user@destination: The username and IP/hostname of the destination server.
+	•	/path/to/target/: The target directory on the destination server.
+
+##### Example:
+
+If you're copying files from /home/cheeto on LSSC0 to /home/cheeto on Hive, run rsync on LSSC0:
+
+`rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/`
+
+Note that this will copy your home directory as-is. Consider putting your LSSC0 files into a oldhome/ directory on Hive to ensure that you're not copying over stale dot files.
+
+`rsync -avz /home/cheeto/ user@hive.hpc.ucdavis.edu:/home/cheeto/oldhome/`
+
+##### Additional options:
+	•	--progress: Shows progress during the file transfer.
+	•	--delete: Deletes files on the destination that are not present on the source.
+	•	-e ssh: Explicitly specifies SSH as the transfer protocol (default when connecting to remote servers).
+
+Please note that you will be asked for your user password when transferring data to Hive. Your username and passphrase is your campus computing account and campus Kerberos passphrase. Alternatively, you can use SSH to transfer data by copying your private key that is associated with your Hive login to LSSC0 and including that with your rsync command as follows:
+
+`rsync -avz -e "ssh -i /path/to/private_key" /source user@remote-server:/destination/`
+
+For example:
+
+`rsync -avz -e "ssh -i $HOME/.ssh/private_key" /home/cheeto/ cheeto@hive.hpc.ucdavis.edu:/home/cheeto/`
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ nav:
       - Job Scheduling: franklin/scheduling.md
       - Resources: franklin/resources.md
       - Storage: franklin/storage.md
+    - Hive:
+      - Migrating from LSSC0: hive/migration.md
+
   - Admin:
     - admin/index.md
     - Network Architecture: admin/network.md


### PR DESCRIPTION
This document references using rsync to transfer data from LSSC0 to Hive. We need this soon as we're going to start migrating users, labs, and servers. Casper has previewed and approved the document.