### PR TITLE
Document how to configure a new PI share backup

### DIFF
--- a/docs/admin/backups-users.md
+++ b/docs/admin/backups-users.md
@@ -9,7 +9,7 @@ title: Home Directory and PI group directory Backups
 
 ## Backups?
 
-For supported clusters, we automatically backup home directories once a day. For supported clusters, PI/group directory
+Currently, HPC@UCD offers backups for Hive. We automatically backup home directories once a day. PI/group directory
 backups can be purchased.
 
 ## What software is used?
@@ -116,9 +116,17 @@ Group directory backups are available by request on Hive. The current rates are 
 
 ### How do I purchase backups for my group directory?
 
-All Hive purchases are through [Hippo](https://hippo.ucdavis.edu/). Select the cluster you are purchasing for, click
-`Orders` -> `Products`. Then order `Backup Storage`. To expedite the process, in the `Notes` section, please include the
-following information:
+<!--
+All Hive purchases are through [Hippo](https://hippo.ucdavis.edu/). Select the cluster you are purchasing for,
+click `Orders` -> `Products`. Then order `Backup Storage`. To expedite the process, in the `Notes` section, please
+include the following information:
+-->
+
+You can purchase backups for your storage by emailing HPC@UCD help and including:
+
+1. The full path to the PI group storage you need backed up.
+
+1. The amount of storage you would like to purchase.
 
 1. The list of contacts (email addresses) that are responsible for monitoring the backup status.
 
@@ -173,15 +181,19 @@ An error will be sent the email address(es) you designated to monitor your backu
 
 At this point you have 4 options:
 
+<!---
 1. Purchase more space by visiting [Hippo](https://hippo.ucdavis.edu/) and ordering additional backup space.
+-->
+
+1. Contacting HPC@UCD support and purchasing additional backup storage space.
 
 1. Backup less data by reducing the amount of data in your `BACKED-UP/` directory. This will require old data to age out
    before new data can be backed up.
 
-1. Ignore it. Eventually old data will age out and new data will be able to backed up again.
+1. Ignore it. Eventually old data should age out and new data should be able to be backed up again.
 
-1. Reduce the number of snapshots you keep by emailing `hpc-help@`ucdavis.edu`. For example, if you keep 6 monthly, you
-   could reduce that to 3. This will age-out (delete) the data greater than 3 months, freeing up space for new data.
+1. Reduce the number of snapshots you keep by contacting HPC@UCD support. For example, if you keep 6 monthly, you could
+   reduce that to 3. This will age-out (delete) the data greater than 3 months, freeing up space for new data.
 
 ### How often are backups taken?
 
@@ -218,16 +230,20 @@ file-system permissions, and only users in the PI group will be able to even rea
 
 Anyone in the PI group can initiate a restore, however, you will only be able to restore files you had read access to at
 the time the file was backed up. This means that files/directories with permissions that prevent PI access on disk also
-prevent PI restore. If you, as a PI, run into this situation, please contact HPC@UCD support by emailing
-`hpc-help@ucdavis.edu` with the following information, and we can restore the files for you.
+prevent PI restore. If you, as a PI, run into this situation, please contact HPC@UCD support by HPC@UCD support with the
+following information, and we can restore the files for you.
 
 -   The cluster.
 -   The full path to the files/directories you need restored.
 -   The full path to the place you would like them restored to.
 
-### How do I make changes to my snapshots or monitoring designee list?
+### How do I make changes to my quota, snapshots or monitoring designee list?
 
-Changes can be made by emailing `hpc-help@ucdavis.edu`.
+Changes can be made by contacting HPC@UCD support.
+
+### How often are backups run?
+
+Backups are run once a day, starting just after midnight.
 
 ## FAQ
 

--- a/docs/admin/backups.md
+++ b/docs/admin/backups.md
@@ -5,6 +5,11 @@ title: Proxmox Backup Server new PI backup configuration
 
 ## Proxmox Backup Server new PI backup configuration
 
+### Hive
+
+For Hive, the PBS server is phoenix, the backups can be configured on any Hive system (or fs6), and the initial backup
+should be started from fs6.
+
 #### Phoenix
 
 `./pbs/new-PI-group.sh {CLUSTER} {PI-group-name}` and take note of the token value.

--- a/docs/admin/backups.md
+++ b/docs/admin/backups.md
@@ -1,8 +1,93 @@
 ---
 template: admin.html
-title: Proxmox Backup Server backups
+title: Proxmox Backup Server new PI backup configuration
 ---
 
-## TODO: document how to setup a new PI backup
+## Proxmox Backup Server new PI backup configuration
+
+#### Phoenix
+
+`./pbs/new-PI-group.sh {CLUSTER} {PI-group-name}` and take note of the token value.
+
+???+ Note
+
+    ```console
+    root@phoenix.hpc: ~ # ./pbs/new-PI-group.sh hive {PIgrp}
+    Checking / creating datastore: hive-group-{PIgrp} in /phoenix/proxmox-backup-service/hive/{PIgrp} (slow)
+
+    !!!!! SAVE the value field of this token to the location indicated by the backup script. !!!!!
+    Result: {
+    "tokenid": "{PIgrp}@pbs!pbs-hive-{PIgrp}",
+    "value": "TOKEN-VALUE-HERE"
+    }
+    ```
+
+#### Hive
+
+```console
+root@hive: ~ # /quobyte/pbs/bin/backup.sh group {PIgrp}
+
+backup.sh: ERROR: no API password at $PBS_PASSWORD_FILE: /quobyte/pbs/group/{PIgrp}/backup.token
+Generate an API token and put the 'value' part in that file.
+```
+
+Paste the token into the indicated file:
+
+```console
+root@hive: ~ # vim /quobyte/pbs/group/{PIgrp}/backup.token
+```
+
+Generate the default config file and other required files.
+
+```console
+root@hive: ~ # /quobyte/pbs/bin/backup.sh group {PIgrp}
+/quobyte/{PIgrp}/.pbs/config does not exist, creating default.
+Now you need to edit /quobyte/{PIgrp}/.pbs/config to set the QUOTA_IN_TB.
+```
+
+Edit the config file to set the quota, adjust the snapshots to keep, and set the email addresses of users who will
+receive the backup status.
+
+```console
+root@hive: ~ # vim /quobyte/{PIgrp}/.pbs/config
+```
+
+??? Note "Default config file"
+
+    ```console
+    # This is the amount of backup or archive space you have purchased.
+    # See https://docs.hpc.ucdavis.edu/backups for details.
+    QUOTA_IN_TB="0" # <--- EDIT
+
+    # How many snapshots to keep. Available types are:
+    # --keep-last
+    # --keep-daily
+    # --keep-weekly
+    # --keep-monthly
+    # --keep-yearly
+    # Simulator: https://pbs.proxmox.com/docs/prune-simulator/
+    ### NOTE: leave empty to indicate no snapshots of that type.
+    KEEP_LAST=
+    KEEP_DAILY=14  # <--- EDIT
+    KEEP_WEEKLY=5  # <--- EDIT
+    KEEP_MONTHLY=3 # <--- EDIT
+    KEEP_YEARLY=
+
+    # A list of space separated email addresses to send PBS output to.
+    MAIL_TO="" # <--- EDIT
+    ```
+
+Finally, start the backup. Depending on the amount of data already in `{PIgrp}/BACKED-UP`, this may take multiple days,
+so run the initial backup in screen and monitor closely.
+
+```console
+root@fs6: ~ # screen
+root@fs6: ~ # /quobyte/pbs/bin/backup.sh group {PIgrp}
+```
+
+### Puppet
+
+Once the initial backup finishes, edit `data/backups.yaml` and add `{PIgrp}` to the list so it is backed up
+automatically.
 
 ## TODO: explain the layout

--- a/docs/backups/index.md
+++ b/docs/backups/index.md
@@ -1,13 +1,8 @@
 ---
-template: admin.html
 title: Home Directory and PI group directory Backups
 ---
 
-???+ failure
-
-    This is internal, for development purposes. **CURRENTLY THERE ARE NO BACKUPS FOR ANY HPC CLUSTERS**.
-
-## Backups?
+## Backups? Backups!
 
 Currently, HPC@UCD offers backups for Hive. We automatically backup home directories once a day. PI/group directory
 backups can be purchased.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - General:
       - Accessing Clusters: general/access.md
       - Account Requests: general/account-requests.md
+      - Backups: backups/index.md
       - Data Transfer: data-transfer.md
       - Job Scheduling:
           - About: scheduler/index.md
@@ -45,7 +46,6 @@ nav:
 
   - Admin:
       - admin/index.md
-      - Backups UF: admin/backups-users.md
       - Backups: admin/backups.md
       - Cobbler: admin/cobbler.md
       - Configuration: admin/configuration.md # puppet, etc


### PR DESCRIPTION
Plus move the user docs to the public (non-admin) area, remove references to purchasing on Hippo, and some wording tweaks.