### PR TITLE
Remove references to HPC2

### DIFF
--- a/docs/general/access.md
+++ b/docs/general/access.md
@@ -277,9 +277,3 @@ shown in the error output (`ssh-keygen -f ...`). If they do not match, [open a s
 
 -   `ECDSA: SHA256:AmJ+z2miIMXlSAcm7k8YwKlIWk5+VqxyT0R4q3fvpcA`
 -   `ED25519: SHA256:b5nv86Ciaqg1yrUVai6bZ0Hk4IpzAFLWtIPDBdacbQM`
-
-#### HPC2 (`hpc2.engr.ucdavis.edu`)
-
--   `RSA: SHA256:ZC23UiJLib0sozDEClkmD5q+TgeZf/mol6xzIQY30xE`
--   `ECDSA: SHA256:ymN3g0Ow4BM2Rd/zE3THZg7nv+mOs75ENCe5GcvWQoM`
--   `ED25519: SHA256:Svzxx62P/NxrsISeyPZ06nW+YkDYsE1xQc1wD/61tFI`

--- a/docs/general/account-requests.md
+++ b/docs/general/account-requests.md
@@ -80,4 +80,6 @@ You will not be able to see any group or sponsor changes until Hippo synchronize
 
 ## HPC2
 
-Users who are associated with PIs in the College of Engineering can request an account on HPC2 by filling out [this form](https://hpc.ucdavis.edu/form/account-request-form).
+As of July 2026, the HPC2 hardware has been [integrated](https://hpc.ucdavis.edu/hpc2-migration-hive) with Hive.
+
+Users can request accounts through [HiPPO](#how-to-request-a-new-account-on-a-cluster).

--- a/docs/general/troubleshooting.md
+++ b/docs/general/troubleshooting.md
@@ -4,7 +4,7 @@ Here are some of the most common issues users face when using SSH.
 
 ### Keys
 
-The following clusters use SSH keys: Farm, Franklin, Hive, and HPC2.
+The following clusters use SSH keys: Farm, Franklin, and Hive.
 
 If you connect to one of these and are asked for a password (as distinct from a passphrase for your key), your key is
 not being recognized. This is usually because of permissions or an unexpected filename. SSH expects your key to be one
@@ -23,9 +23,6 @@ If you kept the default value, your permissions should be set so that only you c
 ```bash
 chmod 600 $HOME/.ssh/id_rsa
 ```
-
-On HPC2, your public key is kept in `$HOME/.ssh/authorized_keys`. Please make sure to not remove your key from this
-file. Doing so will cause you will lose access.
 
 ## Common Slurm Scheduler Issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,7 @@ cycle of support, facilitating greater access to HPC for a more significant numb
 support for college-level needs. HPC@UCD offers two tiers of support moving forward and incentives to merge existing
 hardware with the new cluster when possible.
 
-**HPC2**: Sponsored by the College of Engineering and Computer Science and is open to principal investigators associated
-with CoE.
+**HPC2**: As of July 2026, the HPC2 hardware has been [integrated](https://hpc.ucdavis.edu/hpc2-migration-hive) with Hive.
 
 ## How to request help
 


### PR DESCRIPTION
The HPC2 hardware is now integrated with Hive, so remove the references to HPC2.